### PR TITLE
Fix HTTP to listen to everyone (fix for Docker run time)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go/src/sebatibot
 RUN glide install
 RUN go install
 
-ENV GO_ENV_PORT=8000
+ENV GO_ENV_PORT=3000
 EXPOSE $GO_ENV_PORT
 
 ENTRYPOINT /go/bin/sebatibot

--- a/main.go
+++ b/main.go
@@ -48,8 +48,8 @@ func main() {
 
 	updates := bot.ListenForWebhook("/" + telegramToken)
 
-	log.Debugf("Listening at 127.0.0.1:3000 for Telegram updates. . .")
-	go http.ListenAndServe("127.0.0.1:3000", app)
+	log.Debugf("Listening at 0.0.0.0:3000 for Telegram updates. . .")
+	go http.ListenAndServe("0.0.0.0:3000", app)
 
 	for update := range updates {
 		log.Debugf("%+v\n", update)


### PR DESCRIPTION
Fix Docker to be able to server HTTP to host machine.

### Description
Update `main.go` to listen to all IPs instead of local machine only.
Listen to local machine would mean that host machine would not be able to access Docker's HTTP.

### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required so that it does not have any problems whenever we deploy to Elastic Beanstalk.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

### Screenshots (if appropriate):
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Easily mergable to master (no merge conflicts)
